### PR TITLE
Update confluent kafka-streams-protobuf-serde to 6.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: olafurpg/setup-scala@v2
-    - uses: coursier/cache-action@v3
+    - uses: olafurpg/setup-scala@v13
+    - uses: coursier/cache-action@v6.3
     - run: csbt clean coverage test coverageReport
     - run: bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val root = project
       name := "kafka-streams-scalapb-serde",
       organization := "com.github.scoquelin",
       scalaVersion := "2.13.3",
-      crossScalaVersions := List("2.12.10", "2.13.3"),
+      crossScalaVersions := List("2.12.15", "2.13.7"),
       scalacOptions += "-deprecation"
   )
 
@@ -26,8 +26,8 @@ resolvers += "confluent" at "https://packages.confluent.io/maven/"
 
 libraryDependencies ++= Seq(
     "com.thesamet.scalapb" %% "scalapb-runtime"              % scalapb.compiler.Version.scalapbVersion % "protobuf",
-    "io.confluent"          % "kafka-streams-protobuf-serde" % "5.5.1",
-    "org.scalatest"        %% "scalatest"                    % "3.2.0"  % Test
+    "io.confluent"          % "kafka-streams-protobuf-serde" % "6.0.2",
+    "org.scalatest"        %% "scalatest"                    % "3.2.9"  % Test
 )
 
 PB.targets in Compile := Seq(

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0-RC1")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.8"
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.1"


### PR DESCRIPTION
- Updated github actions versions that were outdated
- Updated `kafka-streams-protobuf-serde` to `6.0.2`
- Updated scala minor versions for `2.12` and `2.13`
- Updated `scalapb` version to `0.11.1`
- Updated minor version for `scalatest`
